### PR TITLE
Feature split for settings is done

### DIFF
--- a/packages/client/src/pages/Settings/Settings.tsx
+++ b/packages/client/src/pages/Settings/Settings.tsx
@@ -10,6 +10,7 @@ import SettingsPlanBeta from "./SettingsPlanBeta";
 import SettingsSlackBeta from "./SettingsSlackBeta";
 import SettingsSMSBeta from "./SettingsSMSBeta";
 import SettingsTeamBeta from "./SettingsTeamBeta";
+import RenderWhenOn from "components/splitFeature/RenderWhenOn";
 
 enum TabName {
   ACCOUNT = "Account",
@@ -85,18 +86,23 @@ const Settings = () => {
                       <div className="border-b border-gray-200">
                         <nav className="-mb-px flex space-x-8">
                           {Object.keys(tabComponents).map((tab) => (
-                            <div
+                            <RenderWhenOn
+                              featureName={`settings-${tab.toLowerCase()}`}
                               key={tab}
-                              className={classNames(
-                                tab === currentTab
-                                  ? "border-cyan-500 text-cyan-600"
-                                  : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700",
-                                "whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm cursor-pointer"
-                              )}
-                              onClick={() => setCurrentTab(tab as TabName)}
                             >
-                              {tab}
-                            </div>
+                              <div
+                                key={tab}
+                                className={classNames(
+                                  tab === currentTab
+                                    ? "border-cyan-500 text-cyan-600"
+                                    : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700",
+                                  "whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm cursor-pointer"
+                                )}
+                                onClick={() => setCurrentTab(tab as TabName)}
+                              >
+                                {tab}
+                              </div>
+                            </RenderWhenOn>
                           ))}
                         </nav>
                       </div>

--- a/packages/client/src/pages/Settings/SettingsEmailBeta.tsx
+++ b/packages/client/src/pages/Settings/SettingsEmailBeta.tsx
@@ -11,6 +11,7 @@ import {
 } from "reducers/settings.reducer";
 import { useDispatch } from "react-redux";
 import { AxiosError } from "axios";
+import RenderWhenOn from "components/splitFeature/RenderWhenOn";
 
 const memoryOptions: Record<
   string,
@@ -658,25 +659,30 @@ export default function SettingsEmailBeta() {
             </RadioGroup.Label>
             <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
               {Object.values(memoryOptions).map((option) => (
-                <RadioGroup.Option
+                <RenderWhenOn
+                  featureName={`settings-email-${option.id}`}
                   key={option.name}
-                  value={option}
-                  className={({ active, checked }) =>
-                    classNames(
-                      option.inStock
-                        ? "cursor-pointer focus:outline-none"
-                        : "opacity-25 cursor-not-allowed",
-                      active ? "ring-2 ring-offset-2 ring-cyan-500" : "",
-                      checked
-                        ? "bg-cyan-600 border-transparent text-white hover:bg-cyan-700"
-                        : "bg-white border-gray-200 text-gray-900 hover:bg-gray-50",
-                      "border rounded-md py-3 px-3 flex items-center justify-center text-sm font-medium sm:flex-1"
-                    )
-                  }
-                  disabled={!option.inStock}
                 >
-                  <RadioGroup.Label as="span">{option.name}</RadioGroup.Label>
-                </RadioGroup.Option>
+                  <RadioGroup.Option
+                    key={option.name}
+                    value={option}
+                    className={({ active, checked }) =>
+                      classNames(
+                        option.inStock
+                          ? "cursor-pointer focus:outline-none"
+                          : "opacity-25 cursor-not-allowed",
+                        active ? "ring-2 ring-offset-2 ring-cyan-500" : "",
+                        checked
+                          ? "bg-cyan-600 border-transparent text-white hover:bg-cyan-700"
+                          : "bg-white border-gray-200 text-gray-900 hover:bg-gray-50",
+                        "border rounded-md py-3 px-3 flex items-center justify-center text-sm font-medium sm:flex-1"
+                      )
+                    }
+                    disabled={!option.inStock}
+                  >
+                    <RadioGroup.Label as="span">{option.name}</RadioGroup.Label>
+                  </RadioGroup.Option>
+                </RenderWhenOn>
               ))}
             </div>
           </RadioGroup>

--- a/packages/client/src/pages/Settings/SettingsSMSBeta.tsx
+++ b/packages/client/src/pages/Settings/SettingsSMSBeta.tsx
@@ -2,6 +2,7 @@ import { RadioGroup } from "@headlessui/react";
 import { ExclamationCircleIcon } from "@heroicons/react/20/solid";
 import { Input } from "components/Elements";
 import SaveSettings from "components/SaveSettings";
+import RenderWhenOn from "components/splitFeature/RenderWhenOn";
 import { ChangeEvent, FocusEvent, ReactNode, useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { useDebounce } from "react-use";
@@ -487,25 +488,30 @@ export default function SettingsSMSBeta() {
             </RadioGroup.Label>
             <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
               {Object.values(memoryOptions).map((option) => (
-                <RadioGroup.Option
+                <RenderWhenOn
+                  featureName={`settings-sms-${option.id}`}
                   key={option.name}
-                  value={option}
-                  className={({ active, checked }) =>
-                    classNames(
-                      option.inStock
-                        ? "cursor-pointer focus:outline-none"
-                        : "opacity-25 cursor-not-allowed",
-                      active ? "ring-2 ring-offset-2 ring-cyan-500" : "",
-                      checked
-                        ? "bg-cyan-600 border-transparent text-white hover:bg-cyan-700"
-                        : "bg-white border-gray-200 text-gray-900 hover:bg-gray-50",
-                      "border rounded-md py-3 px-3 flex items-center justify-center text-sm font-medium sm:flex-1"
-                    )
-                  }
-                  disabled={!option.inStock}
                 >
-                  <RadioGroup.Label as="span">{option.name}</RadioGroup.Label>
-                </RadioGroup.Option>
+                  <RadioGroup.Option
+                    key={option.name}
+                    value={option}
+                    className={({ active, checked }) =>
+                      classNames(
+                        option.inStock
+                          ? "cursor-pointer focus:outline-none"
+                          : "opacity-25 cursor-not-allowed",
+                        active ? "ring-2 ring-offset-2 ring-cyan-500" : "",
+                        checked
+                          ? "bg-cyan-600 border-transparent text-white hover:bg-cyan-700"
+                          : "bg-white border-gray-200 text-gray-900 hover:bg-gray-50",
+                        "border rounded-md py-3 px-3 flex items-center justify-center text-sm font-medium sm:flex-1"
+                      )
+                    }
+                    disabled={!option.inStock}
+                  >
+                    <RadioGroup.Label as="span">{option.name}</RadioGroup.Label>
+                  </RadioGroup.Option>
+                </RenderWhenOn>
               ))}
             </div>
           </RadioGroup>


### PR DESCRIPTION
It's done
Feature Name convention:
settings-[name of the tab], for example settings-email

and for inner tabs for Email and sms:

settings-email-[name of provider] ex. settings-email-sendgrid
settings-sms-[name of provider] ex. settings-sms-twillio

Thanks.