### PR TITLE
Handle twillo error

### DIFF
--- a/packages/client/src/pages/Settings/SettingsSMSBeta.tsx
+++ b/packages/client/src/pages/Settings/SettingsSMSBeta.tsx
@@ -161,7 +161,11 @@ export default function SettingsSMSBeta() {
       url: `/sms/possible-phone-numbers?smsAccountSid=${smsAccountSid}&smsAuthToken=${smsAuthToken}`,
     });
 
-    setPossibleNumbers(data || []);
+    if (!data.success) {
+      toast.error(data.message);
+    } else {
+      setPossibleNumbers(data || []);
+    }
   };
 
   useDebounce(

--- a/packages/server/src/api/sms/sms.service.ts
+++ b/packages/server/src/api/sms/sms.service.ts
@@ -74,10 +74,16 @@ export class SmsService {
     session: string
   ) {
     const twilioClient = twilio(smsAccountSid, smsAuthToken);
-    const results = await twilioClient.incomingPhoneNumbers.list({
-      limit: 20,
-    });
-
-    return results.map((item) => item.phoneNumber);
+    try {
+      const results = await twilioClient.incomingPhoneNumbers.list({
+        limit: 20,
+      });
+      return results.map((item) => item.phoneNumber);
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Unable to fetch phone numbers from Twilio',
+      };
+    }
   }
 }


### PR DESCRIPTION
When there's an error while fetching the sender from numbers, Show a user-friendly error message.